### PR TITLE
Migrate from Loom to FG + Update to 1.6.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,5 @@ bin/
 
 *.DS_Store
 
-# fabric
-
 run/
+run-data/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 Repositories you can use for additional reference:
 
-- [Juiceycality](https://github.com/JuiceyBeans/Juiceycality)
 - [CosmicCore](https://github.com/Frontiers-PackForge/CosmicCore)
 - [Gregicality Rocketry](https://github.com/Argent-Matter/gcyr/)
+- [Gregtech: Extended Chemistry Extended](https://github.com/jmoiron/Gregtech-Extended-Chemistry)
+- [Juiceycality](https://github.com/JuiceyBeans/Juiceycality)

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,8 @@
 plugins {
-    id "dev.architectury.loom" version "1.6-SNAPSHOT"
+    id "idea"
     id "maven-publish"
-}
-
-base {
-    archivesName = project.archives_base_name
-}
-
-version = project.mod_version
-group = project.maven_group
-
-java {
-    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_17
+    id 'net.minecraftforge.gradle' version '[6.0,6.2)'
+    id 'org.parchmentmc.librarian.forgegradle' version '1.+'
 }
 
 def generatedResources = file("src/generated")
@@ -22,44 +13,8 @@ sourceSets {
     }
 }
 
-loom {
-    // use this if you are using the official mojang mappings
-    // and want loom to stop warning you about their license
-    silentMojangMappingsLicense()
-
-    // since loom 0.10, you are **required** to use the
-    // "forge" block to configure forge-specific features,
-    // such as the mixinConfigs array or datagen
-    forge {
-        // specify the mixin configs used in this mod
-        // this will be added to the jar manifest as well!
-        //mixinConfigs = [
-        //        "examplemod.mixins.json"
-        //]
-
-        // missing access transformers?
-        // don't worry, you can still use them!
-        // note that your AT *MUST* be located at
-        // src/main/resources/META-INF/accesstransformer.cfg
-        // to work as there is currently no config option to change this.
-        // also, any names used in your access transformer will need to be
-        // in SRG mapped ("func_" / "field_" with MCP class names) to work!
-        // (both of these things may be subject to change in the future)
-	dataGen{
-            mod(mod_id)
-        }
-    }
-	runConfigs.named("data").configure {
-        programArg("--existing=" + file("src/main/resources").absolutePath)
-        programArgs("--client", "--server")
-    }
-}
-
 repositories {
     mavenLocal()
-    flatDir {
-        dir 'libs'
-    }
     mavenCentral()
     maven {
         name = 'GTCEu Maven'
@@ -71,14 +26,6 @@ repositories {
     maven {
         name 'FirstDarkDev'
         url "https://maven.firstdarkdev.xyz/snapshots/"
-    }    
-    maven {
-        name 'Quilt'
-        url 'https://maven.quiltmc.org/repository/release/'
-    }
-    maven {
-        name = 'ParchmentMC'
-        url = 'https://maven.parchmentmc.org'
     }
     maven {
         // saps.dev Maven (KubeJS and Rhino)
@@ -91,9 +38,7 @@ repositories {
         url = "https://maven.tterrag.com/"
         content {
             // need to be specific here due to version overlaps
-            includeGroup("com.jozufozu.flywheel")
             includeGroup("com.tterrag.registrate")
-            includeGroup("com.simibubi.create")
         }
     }
     maven {
@@ -116,42 +61,71 @@ repositories {
 		name = "TerraformersMC"
 		url = "https://maven.terraformersmc.com/"
 	}
+
+    maven {
+        url = "https://maven.architectury.dev"
+    }
+    maven {
+        url = "https://thedarkcolour.github.io/KotlinForForge/"
+    }
+
+}
+
+version = mod_version
+group = maven_group
+base { archivesName = archives_base_name }
+java { sourceCompatibility = targetCompatibility = JavaVersion.VERSION_17 }
+sourceSets.main.resources { srcDir 'src/generated/resources' }
+
+minecraft {
+    mappings channel: mapping_channel, version: mapping_version
+    copyIdeResources = true
+    runs {
+        configureEach {
+            workingDirectory project.file('run')
+            property 'forge.logging.markers', 'REGISTRIES'
+            property 'forge.logging.console.level', 'debug'
+            mods { "${mod_id}" { source sourceSets.main } }
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${buildDir}/createSrgToMcp/output.srg"
+        }
+        client { property 'forge.enabledGameTestNamespaces', mod_id }
+        server { property 'forge.enabledGameTestNamespaces', mod_id; args '--nogui' }
+        data {
+            // example of overriding the workingDirectory set in configureEach above
+            workingDirectory project.file('run-data')
+
+            // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
+            args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+        }
+    }
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:$project.minecraft_version"
-    forge "net.minecraftforge:forge:$project.minecraft_version-$project.forge_version"
-    // layered mappings - Mojmap names, parchment and QM docs and parameters
-    mappings loom.layered {
-        it.mappings("org.quiltmc:quilt-mappings:$project.minecraft_version+build.$project.quilt_mappings:intermediary-v2")
-        it.parchment("org.parchmentmc.data:parchment-$project.minecraft_version:$project.parchment_mappings@zip")
-        it.officialMojangMappings { nameSyntheticMembers = false }
-    }
+    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    modCompileOnly("mezz.jei:jei-$project.minecraft_version-forge-api:$project.jei_version") { transitive = false }
-    modCompileOnly("mezz.jei:jei-$project.minecraft_version-common-api:$project.jei_version") { transitive = false }
+    // JEI, EMI, Jade
+    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
+    runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
+    runtimeOnly fg.deobf("dev.emi:emi-forge:${emi_version}+${minecraft_version}")
+    runtimeOnly fg.deobf("curse.maven:jade-324717:5390389")
 
-    modImplementation("com.gregtechceu.gtceu:gtceu-$project.minecraft_version:$project.gtceu_version") { transitive = false }
-    modImplementation("com.lowdragmc.ldlib:ldlib-forge-$project.minecraft_version:$project.ldlib_version") { transitive = false }
-    modImplementation("com.tterrag.registrate:Registrate:$project.registrate_version")
-    modImplementation("dev.latvian.mods:kubejs-forge:$project.kubejs_version")
-
-    modRuntimeOnly("dev.toma.configuration:configuration-forge-$project.minecraft_version:$project.configuration_version")
-    modRuntimeOnly("mezz.jei:jei-$project.minecraft_version-forge:$project.jei_version") { transitive = false }
-    
-    modRuntimeOnly ("dev.emi:emi-forge:$project.emi_version+$project.minecraft_version")
-
-    // Mixin Extras
-    implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:$project.mixinextras_version"))
-    implementation(include("io.github.llamalad7:mixinextras-forge:$project.mixinextras_version"))
+    // GregTech and dependencies
+    implementation fg.deobf("com.gregtechceu.gtceu:gtceu-${minecraft_version}:${gtceu_version}:slim") { transitive = false }
+    implementation fg.deobf("com.lowdragmc.ldlib:ldlib-forge-${minecraft_version}:${ldlib_version}") { transitive = false }
+    implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
+    implementation fg.deobf("dev.latvian.mods:kubejs-forge:${kubejs_version}")
+    implementation fg.deobf("dev.latvian.mods:rhino-forge:${rhino_version}")
+    runtimeOnly fg.deobf("dev.toma.configuration:configuration-forge-${minecraft_version}:${configuration_version}")
+    runtimeOnly fg.deobf("dev.architectury:architectury-forge:${architectury_version}")
 
     // lombok
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
 }
 
-processResources {
-    // set up properties for filling into metadata
+tasks.named('processResources', ProcessResources).configure {
     var properties = [
             "mod_license": mod_license,
             "mod_id": mod_id,
@@ -166,10 +140,11 @@ processResources {
     inputs.properties(properties)
 
     filesMatching("META-INF/mods.toml") {
-        expand properties
+        expand properties + [project: project]
     }
 }
 
+tasks.named('jar', Jar).configure { finalizedBy 'reobfJar' }
 tasks.withType(JavaCompile).configureEach {
     // ensure that the encoding is set to UTF-8, no matter what the system default is
     // this fixes some edge cases with special characters not displaying correctly
@@ -177,43 +152,4 @@ tasks.withType(JavaCompile).configureEach {
     // If Javadoc is generated, this must be specified in that task too.
     options.encoding = "UTF-8"
     options.release.set(17)
-}
-
-java {
-    // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-    // if it is present.
-    // If you remove this line, sources will not be generated.
-    withSourcesJar()
-}
-
-jar {
-    // add some additional metadata to the jar manifest
-    manifest {
-        attributes([
-                "Specification-Title"     : mod_id,
-                "Specification-Vendor"    : mod_author,
-                "Specification-Version"   : "1",
-                "Implementation-Title"    : project.name,
-                "Implementation-Version"  : version,
-                "Implementation-Vendor"   : mod_author,
-                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
-        ])
-    }
-}
-
-// configure the maven publication
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-        }
-    }
-
-    // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
-    repositories {
-        // Add repositories to publish to here.
-        // Notice: This block does NOT have the same function as the block in the top level.
-        // The repositories here will be used for publishing your artifact, not for
-        // retrieving dependencies.
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,14 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-# tell architectury loom that this project is a forge project.
-# this will enable us to use the "forge" dependency.
-# using archloom without this is possible and will give you a
-# "standard" loom installation with some extra features.
-loom.platform=forge
 
 # Base properties
     # minecraft version
     minecraft_version=1.20.1
     # forge version, latest version can be found on https://files.minecraftforge.net/
-    forge_version=47.3.10
-    parchment_mappings=2023.09.03
-    # quilt mappings, latest version can be found on https://lambdaurora.dev/tools/import_quilt.html
-    quilt_mappings=23
+    forge_version=47.3.0
+    mapping_channel=parchment
+    mapping_version=2023.09.03-1.20.1
 
 # Mod Properties
     mod_version=1.0.0
@@ -27,11 +21,12 @@ loom.platform=forge
     mod_license=LGPLv3.0
 
 # Dependencies
-    gtceu_version=1.4.2
+    architectury_version=9.2.14
+    gtceu_version=1.6.3
     ldlib_version=1.0.28.a
     registrate_version=MC1.20-1.3.11
+    rhino_version=2001.2.3-build.6
     kubejs_version=2001.6.5-build.14
     configuration_version=2.2.0
     jei_version=15.19.0.87
     emi_version = 1.1.13
-    mixinextras_version=0.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,10 +23,10 @@ org.gradle.jvmargs=-Xmx1G
 # Dependencies
     architectury_version=9.2.14
     gtceu_version=1.6.3
-    ldlib_version=1.0.28.a
+    ldlib_version=1.0.31
     registrate_version=MC1.20-1.3.11
     rhino_version=2001.2.3-build.6
     kubejs_version=2001.6.5-build.14
     configuration_version=2.2.0
-    jei_version=15.19.0.87
+    jei_version=15.20.0.105
     emi_version = 1.1.13

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,9 +2,7 @@ pluginManagement {
     // when using additional gradle plugins like shadow,
     // add their repositories to this list!
     repositories {
-        maven { url "https://maven.fabricmc.net/" }
-        maven { url "https://maven.architectury.dev/" }
-        maven { url "https://files.minecraftforge.net/maven/" }
-        gradlePluginPortal()
+        maven { url = 'https://maven.minecraftforge.net/' }
+        maven { url = 'https://maven.parchmentmc.org' }
     }
 }


### PR DESCRIPTION
I would like to dedicate this PR to:
@cyb0124 for migrating WSCore from Loom to FG and letting me steal his build.gradle
@screret fuck you for making the addon template use Loom in the first place :trollface: 
@JuiceyBeans fuck you for deciding to maintain the addon template smh

Shoutout https://github.com/WorldshaperPack/Worldshaper-Core/blob/adb63eab247d8b534af692125fba474f90f9bd1b/build.gradle

- Dropped Arch Loom for ForgeGradle
- Updated to be usable with GTM 1.6.3