### PR TITLE
make version bump more reasonable

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx1G
     mapping_version=2023.09.03-1.20.1
 
 # Mod Properties
-    mod_version=1.0.0
+    mod_version=0.1.0
     maven_group=com.example.examplemod
     archives_base_name=examplemod
     mod_id=examplemod


### PR DESCRIPTION
change starting version on the template to be 0.1.0 vs 1.0.0 to help indicate the addon is in alpha cause semver uses 1.0.0 as a release version