### PR TITLE
fix the addon template and add a dummy mixin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,21 +95,22 @@ legacyForge {
             // You can set various levels here.
             // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
             logLevel = org.slf4j.event.Level.DEBUG
-            sourceSet = sourceSets.main
         }
         client {
             client()
+            sourceSet = sourceSets.main
             programArguments.addAll('--refresh-dependencies')
             systemProperty('forge.enabledGameTestNamespaces', project.mod_id)
         }
         server {
             server()
+            sourceSet = sourceSets.main
             systemProperty('forge.enabledGameTestNamespaces', project.mod_id)
             programArguments.addAll('--nogui', '--world', 'world-extra')
         }
         data {
             data()
-
+            sourceSet = sourceSets.main
             // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
             programArguments.addAll('--mod', project.mod_id, '--all', '--output', file('src/generated/resources/').getAbsolutePath(), '--existing', file('src/main/resources/').getAbsolutePath())
             programArguments.addAll('--existing-mod', 'gtceu')
@@ -151,15 +152,16 @@ dependencies {
     modImplementation("com.gregtechceu.gtceu:gtceu-${minecraft_version}:${gtceu_version}:slim") { transitive = false }
     modImplementation("com.lowdragmc.ldlib:ldlib-forge-${minecraft_version}:${ldlib_version}") { transitive = false }
     modImplementation("com.tterrag.registrate:Registrate:${registrate_version}")
-    modRuntimeOnly("dev.toma.configuration:configuration-forge-${minecraft_version}:${configuration_version}")
+    modImplementation("dev.toma.configuration:configuration-forge-${minecraft_version}:${configuration_version}")
 
     // lombok
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
 }
 
+// See com.example.examplemod.mixin.DummyMixin for information about mixins
 mixin {
-    add sourceSets.main, "${mod_id}.refmap.json"
+    add sourceSets.main, "mixins.${mod_id}.refmap.json"
     config "${mod_id}.mixins.json"
 }
 
@@ -190,4 +192,5 @@ tasks.withType(JavaCompile).configureEach {
     // If Javadoc is generated, this must be specified in that task too.
     options.encoding = "UTF-8"
     options.release.set(17)
+    options.compilerArgs << "-Aquiet=true" // Suppress mixin notes
 }

--- a/src/main/java/com/example/examplemod/ExampleGTAddon.java
+++ b/src/main/java/com/example/examplemod/ExampleGTAddon.java
@@ -39,9 +39,9 @@ public class ExampleGTAddon implements IGTAddon {
     // KubeJS WILL REMOVE YOUR RECIPES IF THESE ARE NOT REGISTERED.
     /*
      * public static final ContentJS<Double> PRESSURE_IN = new ContentJS<>(NumberComponent.ANY_DOUBLE,
-     * GregitasRecipeCapabilities.PRESSURE, false);
+     * CustomRecipeCapabilities.PRESSURE, false);
      * public static final ContentJS<Double> PRESSURE_OUT = new ContentJS<>(NumberComponent.ANY_DOUBLE,
-     * GregitasRecipeCapabilities.PRESSURE, true);
+     * CustomRecipeCapabilities.PRESSURE, true);
      * 
      * @Override
      * public void registerRecipeKeys(KJSRecipeKeyEvent event) {

--- a/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/src/main/java/com/example/examplemod/ExampleMod.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 @Mod(ExampleMod.MOD_ID)
+@SuppressWarnings("removal")
 public class ExampleMod {
 
     public static final String MOD_ID = "examplemod";
@@ -113,7 +114,7 @@ public class ExampleMod {
     }
 
     /**
-     * Used to register your own new RecipeTypes.
+     * Used to register your own new machines.
      * Call init() from your Machine class(es) here
      * 
      * @param event

--- a/src/main/java/com/example/examplemod/mixin/DummyMixin.java
+++ b/src/main/java/com/example/examplemod/mixin/DummyMixin.java
@@ -1,0 +1,14 @@
+package com.example.examplemod.mixin;
+
+import net.minecraft.world.level.levelgen.WorldgenRandom;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+// This is a dummy mixin! It doesn't actually do anything.
+// Mixins are ways to modify code in other classes.
+// They can be very valuable in the right circumstances,
+// but it is generally preferred that you try to use other means
+// to get your code to work before resorting to mixins,
+// as they can be highly invasive.
+@Mixin(value = WorldgenRandom.class, remap = false)
+public class DummyMixin {}

--- a/src/main/resources/examplemod.mixins.json
+++ b/src/main/resources/examplemod.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "mixins": [
+    "DummyMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
As in title. The mixin block in build.gradle would break creating jars if there aren't any mixins present, so I added a dummy mixin that doesn't actually do anything, and used it as an opportunity to mention what mixins are and when to use them.