### PR TITLE
added refmap to mixin.json, updated emi maven (terraformersmc -> sleeping town) and updated forge, emi, jei gtceu version to be more modern

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ repositories {
     }
     maven {
         // EMI
-		name = "TerraformersMC"
-		url = "https://maven.terraformersmc.com/"
+        name = "Sleeping Town"
+        url = "https://repo.sleeping.town/"
 	}
     maven {
         url = "https://thedarkcolour.github.io/KotlinForForge/"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.jvmargs=-Xmx1G
     # minecraft version
     minecraft_version=1.20.1
     # forge version, latest version can be found on https://files.minecraftforge.net/
-    forge_version=47.4.0
+    forge_version=47.4.20
     mapping_channel=parchment
     mapping_version=2023.09.03
 
@@ -21,9 +21,9 @@ org.gradle.jvmargs=-Xmx1G
     mod_license=LGPLv3.0
 
 # Dependencies
-    gtceu_version=7.4.0
+    gtceu_version=7.5.3
     ldlib_version=1.0.40.b
     registrate_version=MC1.20-1.3.11
     configuration_version=2.2.0
-    jei_version=15.20.0.115
-    emi_version = 1.1.13
+    jei_version=15.27.0.158
+    emi_version = 1.1.22

--- a/src/main/resources/examplemod.mixins.json
+++ b/src/main/resources/examplemod.mixins.json
@@ -3,6 +3,7 @@
   "package": "com.example.examplemod.mixin",
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
+  "refmap": "mixins.examplemod.refmap.json",
   "mixins": [
     "DummyMixin"
   ],


### PR DESCRIPTION
- changed the maven that EMI uses from terraformersMC to sleeping town (EMI swapped maven repo's)
- set the forge version to 47.4.20
- set gtceu version to 7.5.3
- set jei version to 15.27.0.158
- set emi version to 1.1.22
- added "refmap": "mixins.examplemod.refmap.json", to examplemod.mixins.json

not entirely sure if ldlib needs to also have a version change, currently it does fully compile and build, 
this pr should bring the template more up to date with latest versions of forge, gtceu, jei and emi, whilst also still being stable

whilst emi also has a 1.1.24 version this version is not compatible with gtceu and thus crashes because ldlib invokes emiplugin too early (known issue not going to be fixed since gtm8 is removing ldlib)

my excuses for the 'your name' commit username, i kind of keep forgetting to set my local git instance username, do tell if i need to do this and resubmit this pr.